### PR TITLE
docs: fix broken Colab + Documentation links, backfill CHANGELOG to 1…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 1.5.4
+
+Autonomous plasticity, cognitive guidance, and production integrity.
+
+### Added
+
+- **Autonomous cognitive plasticity (v5)**
+  - Agents learn from their own inference without fine-tuning or LLM calls
+  - `capture_experience()` / `ingest_experience_batch()` APIs
+  - `PlasticityMode` with anti-hallucination guards, risk scoring, and purge/freeze controls
+- **Cognitive guidance (v6)**
+  - Salience weighting, maintenance-time reflection synthesis, contradiction governance, honest-answer support
+- **Production integrity (v7)**
+  - Concept persistence across restarts; belief reranking active by default
+  - Concept partition cap; internal refactor into dedicated service layers
+- **Operator surfaces**
+  - Startup validation, persistence contract, namespace governance, correction review queues, suggested corrections
+
+## 1.5.1
+
+### Fixed
+
+- MCP stdio transport rewritten to eliminate per-byte read latency
+- MCP `_read_message` supports both `Content-Length` framing and bare JSON lines
+- `Level` serialized to `str` in the `tool_search` response
+
+### Added
+
+- HTTP + SSE MCP server for Make.com, n8n, and other remote clients
+- MCP registry files plus Cursor / Zed install docs; MCP tools table expanded to 11 tools
+
+## 1.5.0
+
+Full cognitive pipeline with activation-based decay.
+
+### Added
+
+- Activation-based decay across the cognitive pipeline (Phase 4 complete)
+- Gemini demo: a cheap model with AuraSDK vs. an expensive model alone
+
+### Fixed
+
+- `ExplicitTrusted` pipeline — 5 gate bugs that blocked policy-hint formation
+- Restored the `relation` module required by the `aura.rs` public API
+
 ## 1.4.1
 
 This release completes the full 5-layer cognitive recall pipeline and ships a convenience API for enabling it in one call.

--- a/examples/colab_quickstart.ipynb
+++ b/examples/colab_quickstart.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AuraSDK — Quickstart (zero install, runs in your browser)\n",
+    "\n",
+    "[AuraSDK](https://github.com/teolex2020/AuraSDK) is a **cognitive memory layer for AI agents**. It learns from interactions — extracting preferences, causal patterns, and behavioral policies — **without any LLM calls, embeddings, cloud, or fine-tuning**.\n",
+    "\n",
+    "This notebook runs the 60-second demo end to end. Just press **Runtime → Run all**.\n",
+    "\n",
+    "- 5-layer cognitive hierarchy: `Record → Belief → Concept → Causal → Policy`\n",
+    "- Fully local & deterministic\n",
+    "- ~3 MB native binary, no heavy dependencies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q aura-memory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create a brain and store interactions\n",
+    "\n",
+    "Memories live at different cognitive levels. `Level.Domain` holds stable knowledge; `Level.Decisions` holds decisions and their outcomes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from aura import Aura, Level\n",
+    "\n",
+    "brain = Aura(tempfile.mkdtemp(prefix=\"aura_demo_\"))\n",
+    "brain.enable_full_cognitive_stack()\n",
+    "\n",
+    "# User preferences (stable knowledge)\n",
+    "preferences = [\n",
+    "    (\"User always reviews code before merging to main branch\", [\"workflow\", \"code-review\"]),\n",
+    "    (\"User prefers detailed error messages over silent failures\", [\"workflow\", \"errors\"]),\n",
+    "    (\"User wants notifications only for critical issues\", [\"notifications\", \"workflow\"]),\n",
+    "    (\"User likes concise answers, not long explanations\", [\"communication\"]),\n",
+    "    (\"User prefers dark mode in all tools\", [\"ui\", \"preferences\"]),\n",
+    "    (\"User schedules deep work in morning, meetings in afternoon\", [\"schedule\", \"productivity\"]),\n",
+    "    (\"User prefers async communication over meetings when possible\", [\"communication\", \"workflow\"]),\n",
+    "]\n",
+    "for content, tags in preferences:\n",
+    "    brain.store(content, level=Level.Domain, tags=tags)\n",
+    "\n",
+    "print(f\"Stored {len(preferences)} preferences\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Decisions and their outcomes\n",
+    "events = [\n",
+    "    (\"Deployed directly to production -- caused 2h outage\", [\"deploy\", \"incident\"], \"deploy-1\"),\n",
+    "    (\"Added staging environment -- caught 3 bugs before prod\", [\"deploy\", \"staging\"], \"deploy-2\"),\n",
+    "    (\"Staging deploy prevented database migration failure\", [\"deploy\", \"staging\", \"database\"], \"deploy-3\"),\n",
+    "    (\"Direct prod deploy skipped staging -- caused data loss\", [\"deploy\", \"incident\"], \"deploy-4\"),\n",
+    "    (\"Staging review caught API breaking change in time\", [\"deploy\", \"staging\", \"api\"], \"deploy-5\"),\n",
+    "    (\"Skipped code review -- introduced security vulnerability\", [\"code-review\", \"security\"], \"review-1\"),\n",
+    "    (\"Code review caught SQL injection before merge\", [\"code-review\", \"security\"], \"review-2\"),\n",
+    "    (\"Code review found performance regression early\", [\"code-review\", \"performance\"], \"review-3\"),\n",
+    "    (\"Merged without review -- broke production auth\", [\"code-review\", \"incident\"], \"review-4\"),\n",
+    "    (\"Critical alert ignored -- escalated to incident\", [\"notifications\", \"incident\"], \"notif-1\"),\n",
+    "    (\"Non-critical noise alerts caused alert fatigue\", [\"notifications\", \"workflow\"], \"notif-2\"),\n",
+    "    (\"Filtered notifications to critical-only -- response time improved\", [\"notifications\", \"workflow\"], \"notif-3\"),\n",
+    "]\n",
+    "ids = {}\n",
+    "for content, tags, key in events:\n",
+    "    result = brain.store(content, level=Level.Decisions, tags=tags)\n",
+    "    ids[key] = result if isinstance(result, str) else result.id\n",
+    "\n",
+    "print(f\"Stored {len(events)} decisions with outcomes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run the learning cycle\n",
+    "\n",
+    "No LLM calls, no cloud, no fine-tuning — pure local computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "for _ in range(5):\n",
+    "    brain.run_maintenance()\n",
+    "print(f\"5 learning cycles complete in {(time.perf_counter() - t0) * 1000:.1f} ms\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. See what the system learned on its own"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "concepts = brain.get_surfaced_concepts(5)\n",
+    "if concepts:\n",
+    "    print(\"Discovered topic clusters:\")\n",
+    "    for c in concepts:\n",
+    "        label = getattr(c, \"label\", None) or getattr(c, \"key\", str(c))\n",
+    "        print(f\"  * {label}  ({len(c.record_ids)} observations, score={c.score:.2f})\")\n",
+    "else:\n",
+    "    print(\"Topic clusters: forming (need more cycles on real data)\")\n",
+    "\n",
+    "hints = brain.get_surfaced_policy_hints(5)\n",
+    "if hints:\n",
+    "    print(\"\\nDerived behavioral policies (no one wrote these rules):\")\n",
+    "    for h in hints:\n",
+    "        action = getattr(h, \"action_kind\", getattr(h, \"action\", \"Recommend\"))\n",
+    "        desc = getattr(h, \"description\", str(h))\n",
+    "        strength = getattr(h, \"strength\", 0.0)\n",
+    "        print(f\"  [{action}] {desc[:70]}  (confidence={strength:.2f})\")\n",
+    "else:\n",
+    "    print(\"\\nBehavioral policies: accumulating (run more cycles on real data)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Recall — what gets injected into your LLM prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for q in [\"deployment decision\", \"code review\", \"user preferences\"]:\n",
+    "    t0 = time.perf_counter()\n",
+    "    results = brain.recall_structured(q, top_k=3, min_strength=0.0)\n",
+    "    elapsed = (time.perf_counter() - t0) * 1000\n",
+    "    print(f'\\nQuery: \"{q}\"  [{elapsed:.2f} ms]')\n",
+    "    for i, r in enumerate(results[:2], 1):\n",
+    "        content = r[\"content\"] if isinstance(r, dict) else r.content\n",
+    "        print(f\"  {i}. {content[:70]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What just happened\n",
+    "\n",
+    "From a handful of interactions the cognitive layer extracted user-preference patterns, causal relationships between decisions and outcomes, and behavioral policies your agent can act on — with **zero LLM calls, zero cloud, zero fine-tuning**, fully offline.\n",
+    "\n",
+    "Next steps:\n",
+    "- ⭐ Star the repo: https://github.com/teolex2020/AuraSDK\n",
+    "- Browse runnable integrations (Ollama, LangChain, Claude SDK, CrewAI, FastAPI, …) in [`examples/`](https://github.com/teolex2020/AuraSDK/tree/main/examples)\n",
+    "- Read the [README](https://github.com/teolex2020/AuraSDK/blob/main/README.md) for the full cognitive architecture"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://aurasdk.dev"
 Repository = "https://github.com/teolex2020/AuraSDK"
-Documentation = "https://github.com/teolex2020/AuraSDK/blob/main/docs/API.md"
+Documentation = "https://github.com/teolex2020/AuraSDK/blob/main/README.md"
 
 [tool.maturin]
 features = ["pyo3/extension-module", "encryption"]


### PR DESCRIPTION
….5.4

- Add examples/colab_quickstart.ipynb so the README "Open In Colab" badge resolves to a real, zero-install notebook (mirrors demo.py, no LLM/cloud). The badge previously 404'd.
- Point pyproject Documentation URL at README.md instead of the nonexistent docs/API.md (was a 404 on PyPI).
- Backfill CHANGELOG with 1.5.0 / 1.5.1 / 1.5.4 entries (it stopped at 1.4.1 while the shipped version is 1.5.4). Entries derived from the public release commit messages.

## What

Brief description of changes.

## Why

What problem this solves or what feature it adds.

## How

Key implementation details (if non-obvious).

## Testing

- [ ] Rust tests pass: `cargo test --no-default-features --features "encryption,audit"`
- [ ] Clippy clean: `cargo clippy --no-default-features --features "encryption,audit" -- -D warnings`
- [ ] Python tests pass: `pytest tests/ -v`
- [ ] New tests added for new functionality

## Checklist

- [ ] Code follows project style (rustfmt, no clippy warnings)
- [ ] No new dependencies added (or justified in description)
- [ ] Backward compatible (or breaking change documented)
- [ ] Docs updated if API changed
